### PR TITLE
Fix bug when a dimension has only one value

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "pc-axis/dataset"
+require_relative "../lib/ruby_px"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/ruby_px/dataset.rb
+++ b/lib/ruby_px/dataset.rb
@@ -123,7 +123,7 @@ module RubyPx
       return if @current_record.nil? || value.nil?
 
       if @type == :data
-        value = value.split(' ')
+        value = value.split(/[\ ;,\t]/).delete_if{ |s| s.blank? }.each(&:strip)
 
         add_value_to_bucket(bucket,value) unless value == [';']
       else
@@ -183,6 +183,7 @@ module RubyPx
             value.strip!
           end
           if bucket[@current_record].nil?
+            value = Array.wrap(value) if @type == :values
             bucket[@current_record] = value
           else
             bucket[@current_record].concat([value])

--- a/spec/fixtures/ine-fenomenos-demograficos-2014-alava-23001.px
+++ b/spec/fixtures/ine-fenomenos-demograficos-2014-alava-23001.px
@@ -1,0 +1,50 @@
+AXIS-VERSION="2006";
+CREATION-DATE="20161124";
+CHARSET="ANSI";
+SUBJECT-AREA="Fenómenos demográficos. Año 2014";
+SUBJECT-CODE="null";
+MATRIX="23001";
+TITLE="Araba/Álava por municipios y fenómeno demográfico .";
+CONTENTS="Araba/Álava";
+CODEPAGE="iso-8859-15";
+DESCRIPTION="";
+COPYRIGHT=YES;
+DECIMALS=0;
+SHOWDECIMALS=0;
+STUB="Municipios";
+HEADING="Fenómeno demográfico","Periodo";
+VALUES("Municipios")="01001 Alegría-Dulantzi","01002 Amurrio","01049 Añana","01003 Aramaio",
+"01006 Armiñón","01037 Arraia-Maeztu","01008 Arrazua-Ubarrundia","01004 Artziniega",
+"01009 Asparrena","01010 Ayala/Aiara","01011 Baños de Ebro/Mañueta","01013 Barrundia",
+"01014 Berantevilla","01016 Bernedo","01017 Campezo/Kanpezu","01021 Elburgo/Burgelu",
+"01022 Elciego","01023 Elvillar/Bilar","01046 Erriberagoitia/Ribera Alta",
+"01056 Harana/Valle de Arana","01901 Iruña Oka/Iruña de Oca","01027 Iruraiz-Gauna",
+"01019 Kripan","01020 Kuartango","01028 Labastida/Bastida","01030 Lagrán",
+"01031 Laguardia","01032 Lanciego/Lantziego","01902 Lantarón",
+"01033 Lapuebla de Labarca","01036 Laudio/Llodio","01058 Legutio","01034 Leza",
+"01039 Moreda de Álava/Moreda Araba","01041 Navaridas","01042 Okondo",
+"01043 Oyón-Oion","01044 Peñacerrada-Urizaharra","01047 Ribera Baja/Erribera Beitia",
+"01051 Salvatierra/Agurain","01052 Samaniego","01053 San Millán/Donemiliaga",
+"01054 Urkabustaiz","01055 Valdegovía/Gaubea","01057 Villabuena de Álava/Eskuernaga",
+"01059 Vitoria-Gasteiz","01060 Yécora/Iekora","01061 Zalduondo","01062 Zambrana",
+"01018 Zigoitia","01063 Zuia";
+VALUES("Fenómeno demográfico")="nacidos vivos por residencia materna",
+"muertes fetales tardías por residencia materna",
+"matrimonios por el lugar en que han fijado residencia",
+"fallecidos por el lugar de residencia","crecimiento vegetativo";
+VALUES("Periodo")="periodopx";
+CODES("Municipios")="01001","01002","01049","01003","01006","01037","01008","01004","01009","01010","01011",
+"01013","01014","01016","01017","01021","01022","01023","01046","01056","01901","01027",
+"01019","01020","01028","01030","01031","01032","01902","01033","01036","01058","01034",
+"01039","01041","01042","01043","01044","01047","01051","01052","01053","01054","01055",
+"01057","01059","01060","01061","01062","01018","01063";
+MAP("Municipios")="muni0109_esp";
+UNITS="fenómenos demográficos";
+SOURCE="Instituto Nacional de Estadística";
+DATA=
+42.0 0.0 10.0 23.0 19.0 99.0 0.0 48.0 75.0 24.0 0.0 0.0 0.0 3.0 -3.0 20.0 0.0 6.0 9.0 11.0 2.0 0.0 0.0 5.0 -3.0 9.0 0.0 2.0 5.0 4.0 7.0 0.0 5.0 7.0 0.0 16.0 0.0 7.0 13.0 3.0 12.0 0.0 4.0 9.0 3.0 31.0 0.0 13.0 22.0 9.0
+ 2.0 0.0 0.0 4.0 -2.0 2.0 0.0 2.0 5.0 -3.0 4.0 0.0 1.0 7.0 -3.0 4.0 0.0 2.0 8.0 -4.0 8.0 0.0 1.0 13.0 -5.0 10.0 0.0 1.0 3.0 7.0 7.0 0.0 5.0 10.0 -3.0 2.0 0.0 0.0 4.0 -2.0 5.0 0.0 1.0 4.0 1.0 0.0 0.0 2.0 6.0 -6.0
+ 28.0 0.0 11.0 10.0 18.0 1.0 0.0 3.0 5.0 -4.0 0.0 0.0 0.0 2.0 -2.0 1.0 0.0 4.0 4.0 -3.0 11.0 0.0 2.0 7.0 4.0 1.0 0.0 2.0 4.0 -3.0 18.0 0.0 3.0 21.0 -3.0 5.0 0.0 3.0 7.0 -2.0 5.0 0.0 1.0 9.0 -4.0 14.0 0.0 4.0 3.0 11.0
+ 140.0 2.0 61.0 179.0 -39.0 21.0 0.0 6.0 11.0 10.0 2.0 0.0 1.0 2.0 0.0 1.0 0.0 0.0 7.0 -6.0 1.0 0.0 0.0 3.0 -2.0 9.0 1.0 6.0 7.0 2.0 40.0 0.0 9.0 22.0 18.0 3.0 0.0 0.0 5.0 -2.0 8.0 0.0 4.0 8.0 0.0 68.0 1.0 32.0 30.0 38.0
+ 0.0 0.0 0.0 5.0 -5.0 6.0 0.0 0.0 7.0 -1.0 17.0 0.0 4.0 8.0 9.0 5.0 0.0 0.0 14.0 -9.0 2.0 0.0 0.0 7.0 -5.0 2554.0 9.0 938.0 1818.0 736.0 2.0 0.0 0.0 3.0 -1.0 2.0 0.0 0.0 2.0 0.0 2.0 0.0 0.0 6.0 -4.0 17.0 0.0 6.0 7.0 10.0
+ 11.0 0.0 6.0 18.0 -7.0;

--- a/spec/ruby_px/dataset_fenomenos_demograficos_spec.rb
+++ b/spec/ruby_px/dataset_fenomenos_demograficos_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe RubyPx::Dataset do
+  let(:subject) { described_class.new 'spec/fixtures/ine-fenomenos-demograficos-2014-alava-23001.px' }
+
+  describe '#headings' do
+    it 'should return the list of headings described in the file' do
+      expect(subject.headings).to eq(['Fenómeno demográfico','Periodo'])
+    end
+  end
+
+  describe '#stubs' do
+    it 'should return the list of stubs described in the file' do
+      expect(subject.stubs).to eq(['Municipios'])
+    end
+  end
+
+  describe 'metadata methods' do
+    it 'should return the title' do
+      expect(subject.title).to eq("Araba/Álava por municipios y fenómeno demográfico .")
+    end
+
+    it 'should return the units' do
+      expect(subject.units).to eq("fenómenos demográficos")
+    end
+
+    it 'should return the source' do
+      expect(subject.source).to eq("Instituto Nacional de Estadística")
+    end
+
+    it 'should return the creation_date' do
+      expect(subject.creation_date).to eq("20161124")
+    end
+  end
+
+  describe '#dimension' do
+    it 'should return all the values of a dimension' do
+      expect(subject.dimension('Fenómeno demográfico')).to include("nacidos vivos por residencia materna")
+      expect(subject.dimension('Fenómeno demográfico')).to include("fallecidos por el lugar de residencia")
+      expect(subject.dimension('Fenómeno demográfico')).to include("crecimiento vegetativo")
+
+      expect(subject.dimension('Periodo')).to eq ['periodopx']
+    end
+
+    it 'should return the number of values' do
+      expect(subject.dimension('Fenómeno demográfico').length).to eq(5)
+      expect(subject.dimension('Periodo').length).to eq(1)
+      expect(subject.dimension('Municipios').length).to eq(51)
+    end
+
+    it 'should return an error if the dimension does not exist' do
+      expect {
+        subject.dimension('foo').values
+      }.to raise_error('Missing dimension foo')
+    end
+  end
+
+  describe '#dimensions' do
+    it 'should return an array with all the dimensions of the dataset' do
+      expect(subject.dimensions).to eq(["Municipios", "Fenómeno demográfico", "Periodo"])
+    end
+  end
+
+  describe '#data' do
+    it 'should raise an error if a dimension value does not exist' do
+      expect {
+        subject.data('Fenómeno demográfico' => 'nacidos', 'Periodo' => 'periodopx', 'Municipios' => '01030 Lagrán')
+      }.to raise_error("Invalid value nacidos for dimension Fenómeno demográfico")
+    end
+
+    it 'should raise an error if a dimension does not exist' do
+      expect {
+        subject.data('foo' => 'Total', 'Periodo' => 'periodopx', 'Municipios' => '01030 Lagrán')
+      }.to raise_error('Missing dimension foo')
+    end
+
+    it 'should return data when all the dimensions are provided' do
+      expect(subject.data('Fenómeno demográfico' => 'nacidos vivos por residencia materna', 'Periodo' => 'periodopx', 'Municipios' => '01030 Lagrán')).to eq('1.0')
+      expect(subject.data('Fenómeno demográfico' => 'muertes fetales tardías por residencia materna', 'Periodo' => 'periodopx', 'Municipios' => '01030 Lagrán')).to eq('0.0')
+      expect(subject.data('Fenómeno demográfico' => 'matrimonios por el lugar en que han fijado residencia', 'Periodo' => 'periodopx', 'Municipios' => '01030 Lagrán')).to eq('2.0')
+      expect(subject.data('Fenómeno demográfico' => 'fallecidos por el lugar de residencia', 'Periodo' => 'periodopx', 'Municipios' => '01030 Lagrán')).to eq('4.0')
+      expect(subject.data('Fenómeno demográfico' => 'crecimiento vegetativo', 'Periodo' => 'periodopx', 'Municipios' => '01030 Lagrán')).to eq('-3.0')
+
+      expect(subject.data('Fenómeno demográfico' => 'nacidos vivos por residencia materna', 'Periodo' => 'periodopx', 'Municipios' => '01063 Zuia')).to eq('11.0')
+      expect(subject.data('Fenómeno demográfico' => 'muertes fetales tardías por residencia materna', 'Periodo' => 'periodopx', 'Municipios' => '01063 Zuia')).to eq('0.0')
+      expect(subject.data('Fenómeno demográfico' => 'matrimonios por el lugar en que han fijado residencia', 'Periodo' => 'periodopx', 'Municipios' => '01063 Zuia')).to eq('6.0')
+      expect(subject.data('Fenómeno demográfico' => 'fallecidos por el lugar de residencia', 'Periodo' => 'periodopx', 'Municipios' => '01063 Zuia')).to eq('18.0')
+      expect(subject.data('Fenómeno demográfico' => 'crecimiento vegetativo', 'Periodo' => 'periodopx', 'Municipios' => '01063 Zuia')).to eq('-7.0')
+    end
+
+    it 'should return an array of data when all the dimensions are provided except 1' do
+      result = subject.data("Periodo"=>"periodopx", "Fenómeno demográfico"=>"nacidos vivos por residencia materna")
+      expect(result.first).to eq('42.0')
+      expect(result.last).to eq('11.0')
+      expect(result.length).to eq(51)
+    end
+
+    it 'should return an error if more than one dimension is expected in the result' do
+      expect {
+        subject.data('Fenómeno demográfico' => 'crecimiento vegetativo')
+      }.to raise_error("Not implented yet, sorry")
+    end
+  end
+end


### PR DESCRIPTION
When a dimension has only one value it needs to be wrapped in an array so
the length used when computing the offset is the one of the array and not
the value string itself.

Adds splitting the data also by `;`  `,` and tabs (according to the pc-axis spec),
instead of only by spaces.