### PR TITLE
Fix multilingual VALUES and equals signs in values

### DIFF
--- a/lib/ruby_px/dataset.rb
+++ b/lib/ruby_px/dataset.rb
@@ -113,7 +113,7 @@ module RubyPx
       @line = line.force_encoding('utf-8').encode('utf-8')
 
       if @current_record.nil?
-        key, value = line.scan(/[^\=]+/)
+        key, value = line.split("=", 2)
         set_current_record(key)
       else
         value = line

--- a/lib/ruby_px/dataset.rb
+++ b/lib/ruby_px/dataset.rb
@@ -155,7 +155,7 @@ module RubyPx
                         elsif key == STUB_RECORD
                           @type = :stubs
                           key
-                        elsif key =~ /\AVALUES/
+                        elsif key =~ /\AVALUES/ && key !~ /\[\w\w\]/
                           @type = :values
                           key.match(/\"([^"]+)\"/)[1]
                         elsif key =~ /\ADATA/


### PR DESCRIPTION
Fixes two issues: multilingual VALUES parsing into too many dimensions (e.g. `VALUES[de]=blabla`) and a record value with an equals sign breaking parsing (e.g. `VALUES="my=value"`