### PR TITLE
Performance in large datasets

### DIFF
--- a/lib/ruby_px/dataset.rb
+++ b/lib/ruby_px/dataset.rb
@@ -4,6 +4,8 @@ require 'open-uri'
 
 module RubyPx
   class Dataset
+    require 'ruby_px/dataset/data'
+
     attr_reader :headings, :stubs
 
     METADATA_RECORDS = %w[TITLE UNITS SOURCE CONTACT LAST-UPDATED CREATION-DATE].freeze
@@ -15,7 +17,7 @@ module RubyPx
       @headings = []
       @stubs = []
       @values = {}
-      @data = []
+      @data = Data.new
 
       parse_resource(resource_uri)
     end
@@ -82,7 +84,7 @@ module RubyPx
           offset += (d ? p * d : p)
         end
 
-        @data[offset]
+        @data.at(offset)
 
       # Return an array of options
       elsif options.length == dimensions.length - 1

--- a/lib/ruby_px/dataset/data.rb
+++ b/lib/ruby_px/dataset/data.rb
@@ -1,0 +1,48 @@
+module RubyPx
+  class Dataset
+    class Data
+
+      CHUNK_SIZE = 5_000
+
+      def initialize
+        @current_chunk_index = 0
+      end
+
+      def at index
+        chunk_index = index/CHUNK_SIZE
+        index_inside_chunk = index%CHUNK_SIZE
+
+        get_chunk(chunk_index)[index_inside_chunk]
+      end
+
+      def concat array
+        current_chunk.concat(array)
+        if current_chunk.size > CHUNK_SIZE
+          excess = current_chunk.pop(current_chunk.size-CHUNK_SIZE)
+          self.current_chunk_index += 1
+          concat(excess)
+        end
+      end
+
+      def indexes_count
+        self.current_chunk_index+1
+      end
+
+      private
+
+      attr_accessor :current_chunk_index
+
+      def current_chunk
+        current = instance_variable_get("@chunk_#{self.current_chunk_index}")
+        return current if current
+
+        instance_variable_set("@chunk_#{self.current_chunk_index}", [])
+      end
+
+      def get_chunk chunk_index
+        instance_variable_get("@chunk_#{chunk_index}")
+      end
+
+    end
+  end
+end

--- a/lib/ruby_px/dataset/data.rb
+++ b/lib/ruby_px/dataset/data.rb
@@ -3,6 +3,7 @@ module RubyPx
     class Data
 
       CHUNK_SIZE = 5_000
+      attr_accessor :current_chunk_index
 
       def initialize
         @current_chunk_index = 0
@@ -30,7 +31,6 @@ module RubyPx
 
       private
 
-      attr_accessor :current_chunk_index
 
       def current_chunk
         current = instance_variable_get("@chunk_#{self.current_chunk_index}")

--- a/spec/ruby_px/dataset/data_spec.rb
+++ b/spec/ruby_px/dataset/data_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RubyPx::Dataset::Data do
+
+  let(:subject) { described_class.new }
+
+  describe '#concat and #at' do
+    it 'should store the values and return them ' do
+      subject.concat (0..12000).to_a
+      subject.concat (12001..32000).to_a
+
+      expect(subject.at(12)).to eq 12
+      expect(subject.at(3475)).to eq 3475
+      expect(subject.at(14223)).to eq 14223
+      expect(subject.at(23987)).to eq 23987
+    end
+  end
+end

--- a/spec/ruby_px/dataset_fenomenos_demograficos_spec.rb
+++ b/spec/ruby_px/dataset_fenomenos_demograficos_spec.rb
@@ -3,7 +3,11 @@
 require 'spec_helper'
 
 describe RubyPx::Dataset do
-  let(:subject) { described_class.new 'spec/fixtures/ine-fenomenos-demograficos-2014-alava-23001.px' }
+  before(:all) do
+    @subject = described_class.new 'spec/fixtures/ine-fenomenos-demograficos-2014-alava-23001.px'
+  end
+
+  let(:subject) { @subject }
 
   context "ine-fenomenos-demograficos-2014-alava-23001.px" do
     describe '#headings' do

--- a/spec/ruby_px/dataset_padron_spec.rb
+++ b/spec/ruby_px/dataset_padron_spec.rb
@@ -3,7 +3,12 @@
 require 'spec_helper'
 
 describe RubyPx::Dataset do
-  let(:subject) { described_class.new 'spec/fixtures/ine-padron-2014.px' }
+  before(:all) do
+    @subject = described_class.new 'spec/fixtures/ine-padron-2014.px'
+  end
+
+  let(:subject) { @subject }
+
 
   context "ine-padron-2014.px" do
     describe '#headings' do


### PR DESCRIPTION
Using a service that handles what used to be a large single array in smaller arrays.

I've tested different `CHUNK_SIZE`options to see if there are faster numbers, but it seems more or less the same (if it's a big number, like 500_000, it gets slower though)